### PR TITLE
Update kona-v2-gpu.dtsi for CUSTOM ROMS

### DIFF
--- a/arch/arm64/boot/dts/vendor/qcom/kona-v2-gpu.dtsi
+++ b/arch/arm64/boot/dts/vendor/qcom/kona-v2-gpu.dtsi
@@ -8,12 +8,12 @@
 	gpu_opp_table_v2: gpu-opp-table_v2 {
 		compatible = "operating-points-v2";
 		
-		opp-941000000 {
-			opp-hz = /bits/ 64 <901000000>;
+		opp-925000000 {
+			opp-hz = /bits/ 64 <925000000>;
 			opp-microvolt = <RPMH_REGULATOR_LEVEL_TURBO_L1>;
 		};
 
-		opp-940000000 {
+		opp-900000000 {
 			opp-hz = /bits/ 64 <900000000>;
 			opp-microvolt = <RPMH_REGULATOR_LEVEL_TURBO_L1>;
 		};
@@ -49,8 +49,8 @@
 			opp-microvolt = <RPMH_REGULATOR_LEVEL_SVS_L0>;
 		};
 
-		opp-305000000 {
-			opp-hz = /bits/ 64 <305000000>;
+		opp-295000000 {
+			opp-hz = /bits/ 64 <295000000>;
 			opp-microvolt = <RPMH_REGULATOR_LEVEL_SVS>;
 		};
 	};
@@ -80,7 +80,7 @@
 
 			qcom,gpu-pwrlevel@0 {
 				reg = <0>;
-				qcom,gpu-freq = <901000000>;
+				qcom,gpu-freq = <925000000>;
 				qcom,bus-freq-ddr7 = <11>;
 				qcom,bus-min-ddr7 = <11>;
 				qcom,bus-max-ddr7 = <11>;
@@ -192,7 +192,7 @@
 
 			qcom,gpu-pwrlevel@8 {
 				reg = <8>;
-				qcom,gpu-freq = <305000000>;
+				qcom,gpu-freq = <295000000>;
 				qcom,bus-freq-ddr7 = <3>;
 				qcom,bus-min-ddr7 = <2>;
 				qcom,bus-max-ddr7 = <9>;
@@ -222,7 +222,7 @@
 			
 			qcom,gpu-pwrlevel@0 {
 				reg = <0>;
-				qcom,gpu-freq = <901000000>;
+				qcom,gpu-freq = <925000000>;
 				qcom,bus-freq-ddr7 = <11>;
 				qcom,bus-min-ddr7 = <11>;
 				qcom,bus-max-ddr7 = <11>;
@@ -334,7 +334,7 @@
 
 			qcom,gpu-pwrlevel@8 {
 				reg = <8>;
-				qcom,gpu-freq = <305000000>;
+				qcom,gpu-freq = <295000000>;
 				qcom,bus-freq-ddr7 = <3>;
 				qcom,bus-min-ddr7 = <2>;
 				qcom,bus-max-ddr7 = <9>;


### PR DESCRIPTION
This GPU register is made for CUSTOM ROMS, NOT RMOS.  RMOS will throttle at a high frequency using this configuration, especially if game mode is turned on.

For details of how the file should be defined for RMOS, see here: https://github.com/mrslezak/NX659J_Q_kernel/blob/ten-dirty/arch/arm64/boot/dts/vendor/qcom/kona-v2-gpu-5freq.dtsi for the RM5G.  For the cooler attachment, 1 more register can be added at 925mhz on the RM5S.  But all the definitions must count from 0 down to pwrlevel#7, and default power levels must be redefined.

Otherwise, the way this is setup, the phone is going to idle at pwrlevel#6.  I'd advise having an LOS / custom build + an RMOS build for this reason.